### PR TITLE
[FRONTEND] Feat: Implement Active, Start, and Finish modals with trip state persistence

### DIFF
--- a/app/_api/auth.jsx
+++ b/app/_api/auth.jsx
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createUserWithEmailAndPassword, getIdToken, signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../../firebaseConfig";
-import { logoutUser, setToken } from "../utils/authStorage";
+import { clearTripState, logoutUser, setToken } from "../utils/authStorage";
 
 export const signUp = async (email, password) => {
   try {
@@ -9,7 +9,7 @@ export const signUp = async (email, password) => {
     const user = userCred.user;
     const idToken = await user.getIdToken(true);
     await setToken(idToken);
-
+    await clearTripState();
     return { success: true, message: "Account created successfully!" };
 
   } catch (err) {
@@ -74,6 +74,7 @@ export const logIn = async (email, password) => {
 export const signOutAccount = async () => {
   try {
     const result = await logoutUser();
+    await clearTripState();
     return {
       success: result.success,
       message: "Logged out locally and Firebase session ended.",

--- a/app/activeModal.jsx
+++ b/app/activeModal.jsx
@@ -10,6 +10,7 @@ import {
   TouchableWithoutFeedback,
   View
 } from 'react-native';
+import { setTripState } from "../app/utils/authStorage";
 
 
 export default function activeModal() {
@@ -18,13 +19,15 @@ export default function activeModal() {
 
   const closeAndGoHome = () => {
     setVisible(false);
-    setTimeout(() => router.replace('/home'), 150);
+    router.replace('/home');    
   };
 
-  const handleConfirm = () => {
-    setVisible(false);           
-    router.replace('/home');          
+  const handleConfirm = async () => {
+    await setTripState("ongoing", "Finish Trip");
+    setVisible(false);
+    router.replace("/home");
   };
+
 
   return (
     <>

--- a/app/finishModal.jsx
+++ b/app/finishModal.jsx
@@ -1,15 +1,25 @@
+import { useRouter } from 'expo-router';
 import { useState } from "react";
 import CustomizableModal from "../app/common/commonModal";
+import { setTripState } from "../app/utils/authStorage";
 
 export default function finishModal() {
+  const router = useRouter();
   const [visible, setVisible] = useState(true);
+
+
+    const handleConfirm = async () => {
+    await setTripState("idle", "Set Active Status");
+    setVisible(false);
+    router.replace("/home");
+  };
 
   return (
     <CustomizableModal
       visible={visible}
       onClose={() => setVisible(false)}
       onCancel={() => setVisible(false)}
-      onConfirm={() => console.log("Confirmed!")}
+      onConfirm={handleConfirm}
 
       title="Want to finish your trip?"
       confirmText="Confirm"

--- a/app/startModal.jsx
+++ b/app/startModal.jsx
@@ -1,15 +1,25 @@
+import { useRouter } from 'expo-router';
 import { useState } from "react";
 import CustomizableModal from "../app/common/commonModal";
+import { setTripState } from "../app/utils/authStorage";
 
 export default function startModal() {
+  const router = useRouter();
   const [visible, setVisible] = useState(true);
+
+  const handleConfirm = async () => {
+    await setTripState("ongoing", "Finish Trip");
+    setVisible(false);
+    router.replace("/home");
+  };
+
 
   return (
     <CustomizableModal
       visible={visible}
       onClose={() => setVisible(false)}
       onCancel={() => setVisible(false)}
-      onConfirm={() => console.log("Confirmed!")}
+      onConfirm={handleConfirm}
 
       title="Want to start your trip?"
       message="Capacity is at 45/45 (Full) \nDrive Safe!"

--- a/app/utils/authStorage.js
+++ b/app/utils/authStorage.js
@@ -4,6 +4,8 @@ import { getAuth, signOut } from "firebase/auth";
 
 const TOKEN_KEY = "firebaseIdToken";
 const USER_KEY = "userData";
+const TRIP_STATUS_KEY = "tripStatus";
+const TRIP_BUTTON_KEY = "tripButtonLabel";
 
 export const setToken = async (token) => {
   try {
@@ -59,5 +61,37 @@ export const logoutUser = async () => {
   } catch (error) {
     console.error("Logout error:", error);
     return { success: false, error };
+  }
+};
+
+export const setTripState = async (status, buttonLabel) => {
+  try {
+    await AsyncStorage.multiSet([
+      [TRIP_STATUS_KEY, status],
+      [TRIP_BUTTON_KEY, buttonLabel],
+    ]);
+  } catch (e) {
+    console.error("Error saving trip state:", e);
+  }
+};
+
+export const getTripState = async () => {
+  try {
+    const values = await AsyncStorage.multiGet([TRIP_STATUS_KEY, TRIP_BUTTON_KEY]);
+    const tripStatus = values[0]?.[1] ?? "idle";
+    const buttonLabel = values[1]?.[1] ?? "Set Active Status";
+    return { tripStatus, buttonLabel };
+  } catch (e) {
+    console.error("Error loading trip state:", e);
+    return { tripStatus: "idle", buttonLabel: "Set Active Status" };
+  }
+};
+
+
+export const clearTripState = async () => {
+  try {
+    await AsyncStorage.multiRemove([TRIP_STATUS_KEY, TRIP_BUTTON_KEY]);
+  } catch (e) {
+    console.error("Error clearing trip state:", e);
   }
 };


### PR DESCRIPTION
- Trip status and corresponding button label are saved to AsyncStorage via `setTripState`.
- Home screen reflects trip state: "Set Active Status" → "Start Your Trip" → "Finish Trip".
- Modals update AsyncStorage and navigate back to home on confirm.
- Also include clearTripState upon logout and signup to ensure fresh trip state for the app 